### PR TITLE
Exclude agent docs from theme zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,6 +72,8 @@ function zipper(done) {
             '!dist', '!dist/**',
             '!pnpm-lock.yaml',
             '!pnpm-workspace.yaml',
+            '!AGENTS.md',
+            '!CLAUDE.md',
             '!gulpfile.js'
         ]),
         zip(filename),


### PR DESCRIPTION
## Summary
- Excludes `AGENTS.md` and `CLAUDE.md` from the theme zip source globs.
- Keeps generated theme archives limited to runtime theme content.

## Validation
- `pnpm zip`, with the generated archive inspected for `AGENTS.md` / `CLAUDE.md`.
