### PR TITLE
Renamed CI gate job to the org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
 
       - run: pnpm test
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires a status check named exactly **All tests pass**. Requiring an individual/legacy check name couples the branch ruleset to the CI matrix: rename the job or restructure the workflow and the required check silently stops existing, blocking every PR.

The org is standardizing every repo on one stable aggregator check named **Required checks pass** (the `repo-ci-required-check` convention), so rulesets everywhere point at the same stable context.

## What changes

- `test.yml`: job id `all-tests-pass` → `required-checks-pass`, job name `All tests pass` → `Required checks pass`.
- Nothing else: same `needs: [test]` coverage, same `if: always()` + failure/cancellation guard, top-level `permissions: contents: read` was already present.

## Coordination

The repo's branch ruleset is being updated in the same pass to require **Required checks pass** instead of **All tests pass**, so this PR must go green on the new gate before merge.